### PR TITLE
Addressing issue 'visaPage needs a reusable method to fill FROM and TO fields'

### DIFF
--- a/pages/loginPage.py
+++ b/pages/loginPage.py
@@ -2,6 +2,7 @@ import time
 from selenium.webdriver.common.by import By
 
 from pages.basePage import BasePage
+from tests.conftest import ConfigC
 
 # ADI
 
@@ -35,7 +36,7 @@ class LoginPage(BasePage):
 
 if __name__ == "__main__":
     # For module testing run from Root folder (ex python pages\loginPage.py)
-    login_page = LoginPage(Config)
+    login_page = LoginPage(ConfigC)
     login_page.load()
     assert login_page.browser.title == "Login - PHPTRAVELS" , "opening of login page failed"
     login_page.login("user@phptravels.com","demouser")

--- a/pages/visaPage.py
+++ b/pages/visaPage.py
@@ -1,4 +1,6 @@
+from multiprocessing.sharedctypes import Value
 import time
+from tests.conftest import ConfigC
 from datetime import datetime
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -15,29 +17,33 @@ class VisaPage(BasePage):
     DATE_PICKER = (By.ID, "date")
     SUBMIT_BTN = (By.ID, "submit")
     TODAY = datetime.today().strftime('%d-%m-%Y')
-    # TODAY_PLUS_10 = DATE_PICKER.__getattribute__("value")
-    # URL_SUBMIT = f"https://www.phptravels.net/visa/submit/ro/us/{TODAY_PLUS_10}"
-    URL_SUBMIT = "https://www.phptravels.net/visa/submit/ro/us/15-04-2022"
 
     def load(self):
         self.browser.get(VisaPage.URL)
         self.browser.maximize_window()
-
-    def RO_to_US(self):
+    
+    def countriesFromTo(self,VISA_FROM_COUNTRY, VISA_TO_COUNTRY):
         self.browser.find_element(*VisaPage.FROM_COUNTRY_DROPDOWN).click()
-        self.browser.find_element(*VisaPage.COUNTRY_INPUT).send_keys("Romania")
+        self.browser.find_element(*VisaPage.COUNTRY_INPUT).send_keys(VISA_FROM_COUNTRY)
         self.browser.find_element(*VisaPage.COUNTRY_INPUT).send_keys(Keys.ENTER)
         self.browser.find_element(*VisaPage.TO_COUNTRY_DROPDOWN).click()
-        self.browser.find_element(*VisaPage.COUNTRY_INPUT).send_keys("United")
-        self.browser.find_element(*VisaPage.COUNTRY_INPUT).send_keys(Keys.ARROW_DOWN)
-        self.browser.find_element(*VisaPage.COUNTRY_INPUT).send_keys(Keys.ARROW_DOWN)
-        self.browser.find_element(*VisaPage.COUNTRY_INPUT).send_keys(Keys.ARROW_DOWN)
+        self.browser.find_element(*VisaPage.COUNTRY_INPUT).send_keys(VISA_TO_COUNTRY)
         self.browser.find_element(*VisaPage.COUNTRY_INPUT).send_keys(Keys.ENTER)
         self.browser.find_element(*VisaPage.SUBMIT_BTN).click()
-    
+
     def close(self):
         self.browser.close()
     
     def screenshot(self):
         date_time = time.strftime("%a.%d.%b.%Y.%H%M%S")
         self.browser.save_screenshot(f"resources\\screenshots\\{date_time}.png")
+
+    def getAttrValue(self, element, atribut):
+        return self.browser.find_element(*element).get_attribute(atribut)
+
+
+if __name__ == "__main__":
+    visapage = VisaPage(ConfigC)
+    visapage.load()
+    valoare = visapage.getAttrValue(VisaPage.DATE_PICKER, "value")
+    visapage.countriesFromTo(ConfigC.VISA_FROM_COUNTRY, ConfigC.VISA_TO_COUNTRY)

--- a/pages/visaPage.py
+++ b/pages/visaPage.py
@@ -1,4 +1,3 @@
-from multiprocessing.sharedctypes import Value
 import time
 from tests.conftest import ConfigC
 from datetime import datetime

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,8 @@ class ConfigC:
     PASSWORD = "demouser"
     PASSWORD_ADMIN = "demoadmin"
     REDIRECT_AFTER_LOGIN_PAGE = "https://www.phptravels.net/account/dashboard"
+    VISA_FROM_COUNTRY = "Romania"
+    VISA_TO_COUNTRY = "United Kingdom"
 
 class ConfigE:
     DRIVER_PATH = os.getcwd() + "\\resources"

--- a/tests/test_visa.py
+++ b/tests/test_visa.py
@@ -1,3 +1,4 @@
+from operator import contains
 from selenium import webdriver
 import time
 from datetime import datetime
@@ -11,12 +12,12 @@ class Test_Visa:
     def setup(self):
         self.visa = VisaPage(ConfigC)
     
-    #submitting
-    def test_RO_to_US(self):
+    #submitting Visa request
+    def testSubmitCountries(self):
         self.visa.load()
-        self.visa.RO_to_US()
+        self.visa.countriesFromTo(ConfigC.VISA_FROM_COUNTRY, ConfigC.VISA_TO_COUNTRY)
         self.visa.screenshot()
-        assert self.visa.browser.current_url == VisaPage.URL_SUBMIT, "The page URL is incorrect."
+        assert "https://www.phptravels.net/visa/submit/" in self.visa.browser.current_url, "The page URL is incorrect."
 
     def teardown(self):
         self.visa.close()


### PR DESCRIPTION
- Added a class to loginPage.py and visaPage.py for module testing run from Root folder;
- Added VISA_FROM_COUNTRY and VISA_TO_COUNTRY constants to conftest.py;
- Modified the RO_to_US  method from visaPage.py to be reusable;
- Renamed the RO_to_US method to countriesFromTo in order to respect method naming conventions;
- Changed the assert method of the URL from the test_visa.py.